### PR TITLE
Make sure installed files have #ddev-generated in them

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [ master, main ]
+    branches: [  main ]
 
   schedule:
   - cron: '01 07 * * *'
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        ddev_version: [stable, edge, HEAD]
+        ddev_version: [stable, HEAD]
 #        ddev_version: [PR]
       fail-fast: false
 

--- a/docker-compose.selenium-standalone.yaml
+++ b/docker-compose.selenium-standalone.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 version: '3.6'
 services:
   selenium:

--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,5 @@
-name: addon-template
+name: ddev-selenium-standalone
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
 - docker-compose.selenium-standalone.yaml
-# - extra_files/
-# - somefile.sh


### PR DESCRIPTION
In upcoming ddev release, files that don't have #ddev-generated in them
won't be able to be overwritten by a future ddev-get, so we need 
to get that into the origin files.
